### PR TITLE
Version 0.1.7

### DIFF
--- a/script.xbmc.subtitles/resources/lib/services/LegendasDivx/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/LegendasDivx/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Version 0.1.8
+# Version 0.1.9
 # Code based on Undertext service
 # Coded by HiGhLaNdR@OLDSCHOOL
 # Help by VaRaTRoN
@@ -31,7 +31,7 @@
 # KNOWN BUGS (TODO for next versions):
 # Regex isn't perfect so a few results might have html tags still, not many but...
 # Filtering languages, shows only European Portuguese flag.
-# Just using .srt subs. Others will come in further versions.
+# Just using .srt subs for auto sync download. Others will come in further versions.
 
 # LegendasDivx.com subtitles, based on a mod of Undertext subtitles
 import os, sys, re, xbmc, xbmcgui, string, time, urllib, urllib2, cookielib, shutil, fnmatch

--- a/script.xbmc.subtitles/resources/lib/services/LegendasDivx/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/LegendasDivx/service.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
-# Version 0.1.7
+# Version 0.1.8
 # Code based on Undertext service
 # Coded by HiGhLaNdR@OLDSCHOOL
+# Help by VaRaTRoN
 # Bugs & Features to highlander@teknorage.com
 # http://www.teknorage.com
 # License: GPL v2
+#
+# FIXED on v0.1.8:
+# Uncompress rar'ed subtitles inside a rar file... yeh weird site...
 #
 # FIXED on v0.1.7:
 # BUG found in multi packs is now fixed.
@@ -308,14 +312,27 @@ def download_subtitles (subtitles_list, pos, zip_subs, tmp_sub_dir, sub_folder, 
 				log( __name__ ,"%s Failed to unpack subtitles in '%s'" % (debug_pretext, tmp_sub_dir))
 			else:
 				log( __name__ ,"%s Unpacked files in '%s'" % (debug_pretext, tmp_sub_dir))
+				searchrars = recursive_glob(tmp_sub_dir, '*.rar')
+				searchrarcount = len(searchrars)
+				log( __name__ ,"%s DEBUG-rarcount: '%s'" % (debug_pretext, searchrarcount))
+				log( __name__ ,"%s DEBUG-rarcount: '%s'" % (debug_pretext, searchrars))
+				if searchrarcount > 1:
+					for filerar in searchrars:
+						log( __name__ ,"%s DEBUG-nomedorar: '%s'" % (debug_pretext, filerar))
+						if filerar != os.path.join(tmp_sub_dir,'ldivx.rar'):
+							#filerar = os.path.join(tmp_sub_dir, filerar)
+							log( __name__ ,"%s DEBUG-nomedorarcompleto: '%s'" % (debug_pretext, filerar))
+							xbmc.executebuiltin("XBMC.Extract(" + filerar + "," + tmp_sub_dir +")")
+				time.sleep(1)
 				searchsubs = recursive_glob(tmp_sub_dir, '*.srt')
+				log( __name__ ,"%s DEBUG-searchsubs: '%s'" % (debug_pretext, searchsubs))
 				searchsubscount = len(searchsubs)
 				for filesub in searchsubs:
 					nopath = string.split(filesub, tmp_sub_dir)[-1]
 					justfile = string.split(nopath, '\\')[-1]
 					#For DEBUG only uncomment next line
-					#log( __name__ ,"%s DEBUG-nopath: '%s'" % (debug_pretext, nopath))
-					#log( __name__ ,"%s DEBUG-justfile: '%s'" % (debug_pretext, justfile))
+					log( __name__ ,"%s DEBUG-nopath: '%s'" % (debug_pretext, nopath))
+					log( __name__ ,"%s DEBUG-justfile: '%s'" % (debug_pretext, justfile))
 					releasefilename = filesearch[1][:len(filesearch[1])-4]
 					releasedirname = string.split(filesearch[0], '/')
 					if 'rar' in israr:


### PR DESCRIPTION
# BUG found in multi packs is now fixed.
# Added more accuracy to the selection of subtitle to load. Now checks the release dirname against the subtitles downloaded.
# When no sync is found and if the substitle name is not equal to the release dirname or release filename it will load one random subtitle from the package.

Signed-off-by: HiGhLaNdR highlander@teknorage.com
