### PR TITLE
Made a change to bypass encode to ascii problem

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -86,10 +86,15 @@ class GUI( xbmcgui.WindowXMLDialog ):
       self.episode = self.episode[-1:]                                      #
 
     self.tvshow    = xbmc.getInfoLabel("VideoPlayer.TVshowtitle")           # Show
-    self.title     = unicodedata.normalize('NFKD', 
+    try :
+        self.title     = unicodedata.normalize('NFKD', 
                       unicode(unicode(xbmc.getInfoLabel
                       ("VideoPlayer.Title"), 'utf-8'))
-                      ).encode('ascii','ignore')                            # Title
+                      ).encode('ascii')                                     # Title
+    except UnicodeEncodeError:
+        originalTitle = xbmc.getInfoLabel("VideoPlayer.OriginalTitle")
+        if not originalTitle == None and not originalTitle == "":
+            self.title     = unicodedata.normalize('NFKD', unicode(originalTitle, 'utf-8')).encode('ascii', 'ignore')
 
     if self.tvshow == "":
       if str(self.year) == "":


### PR DESCRIPTION
Done to support languages that can not be encoded to ascii like hebrew
and arabic. For these languages it tries to find an attribute called
'originalTitle' (should be set by the movie scraper) which holds the
movie title in latin characters that can be converted to ascii.

Change-Id: I66f59a63c8cffe8eb4beed604507d1e7ac9ef3c4
