### PR TITLE
Regular encoding

### DIFF
--- a/script.xbmc.subtitles/default.py
+++ b/script.xbmc.subtitles/default.py
@@ -11,12 +11,12 @@ __scriptname__ = "XBMC Subtitles"
 
 __addon__      = xbmcaddon.Addon(id='script.xbmc.subtitles')
 
-__cwd__        = __addon__.getAddonInfo('path').decode("utf-8")
+__cwd__        = xbmc.translatePath( __addon__.getAddonInfo('path') ).decode("utf-8")
 __version__    = __addon__.getAddonInfo('version')
 __language__   = __addon__.getLocalizedString
 
 __profile__    = xbmc.translatePath( __addon__.getAddonInfo('profile') ).decode("utf-8")
-__resource__   = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ) ).decode("utf-8")
+__resource__   = os.path.join( __cwd__, 'resources', 'lib' )
 
 sys.path.append (__resource__)
 
@@ -30,12 +30,12 @@ if ( __name__ == "__main__" ):
   ui = gui.GUI( "script-XBMC-Subtitles-main.xml" , __cwd__ , "Default")
   movieFullPath = ui.set_allparam()
   if (__addon__.getSetting( "auto_download" ) == "true") and (__addon__.getSetting( "auto_download_file" ) != os.path.basename( movieFullPath )):
-    notification = UserNotificationNotifier(__scriptname__, __language__(764).encode('utf-8'), 2000)    
+    notification = UserNotificationNotifier(__scriptname__, __language__(764), 2000)    
     if not ui.Search_Subtitles(False):
       __unpause__ = pause()
       ui.doModal()
     else:
-      notification.close(__language__(765).encode('utf-8'), 1000) 
+      notification.close(__language__(765), 1000) 
   else:
     __unpause__ = pause() 
     ui.doModal()

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -107,7 +107,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
         else:
           self.sub_folder = os.path.dirname( movieFullPath )
       else:
-        self.sub_folder = os.path.dirname( movieFullPath )   
+        self.sub_folder = os.path.dirname( movieFullPath )
     
     if self.episode.lower().find("s") > -1:                                 # Check if season is "Special"             
       self.season = "0"                                                     #
@@ -164,7 +164,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
         service = name
 
     if len(self.tvshow) > 0:
-      def_service = __addon__.getSetting( "deftvservice") 
+      def_service = __addon__.getSetting( "deftvservice")
     else:
       def_service = __addon__.getSetting( "defmovieservice")
       
@@ -297,17 +297,17 @@ class GUI( xbmcgui.WindowXMLDialog ):
       else:
         file_name = "%s%s" % ( sub_name, sub_ext )
       file_from = file.replace('\\','/')
-      file_to = os.path.join(self.sub_folder.encode("utf-8"), file_name).replace('\\','/')
+      file_to = os.path.join(self.sub_folder, file_name).replace('\\','/')
       # Create a files list of from-to tuples so that multiple files may be
       # copied (sub+idx etc')
       files_list = [(file_from,file_to)]
       # If the subtitle's extension sub, check if an idx file exists and if so
       # add it to the list
-      if ((sub_ext == ".sub") and (os.path.exists(unicode(file[:-3]+"idx", 'utf-8')))):
+      if ((sub_ext == ".sub") and (os.path.exists(file[:-3]+"idx"))):
           log( __name__ ,"found .sub+.idx pair %s + %s" % (file_from,file_from[:-3]+"idx"))
           files_list.append((file_from[:-3]+"idx",file_to[:-3]+"idx"))
       for cur_file_from, cur_file_to in files_list:
-         subtitle_set,file_path  = copy_files( cur_file_from, cur_file_to )  
+         subtitle_set,file_path  = copy_files( cur_file_from, cur_file_to )
       # Choose the last pair in the list, second item (destination file)
       if subtitle_set:
         subtitle = files_list[-1][1]

--- a/script.xbmc.subtitles/resources/lib/services/Shooter/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/Shooter/service.py
@@ -29,12 +29,11 @@ def getBlockHash(f, offset):
     return hashlib.md5(grapBlock(f, offset, 4096)).hexdigest()
 
 def genFileHash(fpath):
-    upath = unicode(fpath, 'utf-8')
-    ftotallen = os.stat(upath).st_size
+    ftotallen = os.stat(fpath).st_size
     if ftotallen < 8192:
         return ""
     offset = [4096, ftotallen/3*2, ftotallen/3, ftotallen - 8192]
-    f = open(upath, "rb")
+    f = open(fpath, "rb")
     return ";".join(getBlockHash(f, i) for i in offset)
 
 def getShortNameByFileName(fpath):
@@ -113,13 +112,13 @@ def downloadSubs(fpath, lang):
         pathinfo = "E:\\" + pathinfo.replace(os.path.sep, "\\")
     filehash = genFileHash(fpath)
     shortname = getShortName(fpath)
-    vhash = genVHash(SVP_REV_NUMBER, fpath, filehash)
+    vhash = genVHash(SVP_REV_NUMBER, fpath.encode("utf-8"), filehash)
     formdata = []
-    formdata.append(("pathinfo", pathinfo))
+    formdata.append(("pathinfo", pathinfo.encode("utf-8")))
     formdata.append(("filehash", filehash))
     if vhash:
         formdata.append(("vhash", vhash))
-    formdata.append(("shortname", shortname))
+    formdata.append(("shortname", shortname.encode("utf-8")))
     if lang != "chn":
         formdata.append(("lang", lang))
     
@@ -230,9 +229,8 @@ def download_subtitles (subtitles_list, pos, zip_subs, tmp_sub_dir, sub_folder, 
     barename = subtitles_list[pos][ "filename" ].rsplit(".",1)[0]
     language = subtitles_list[pos][ "language_name" ]
     for file in subtitles_list[pos][ "filedata" ]:
-        filename = os.path.join(tmp_sub_dir, ".".join([barename, file.ExtName]).decode("utf-8")).encode('utf-8')
-        fn = unicode(filename, 'utf-8')
-        open(fn,"wb").write(file.FileData)
+        filename = os.path.join(tmp_sub_dir, ".".join([barename, file.ExtName]))
+        open(filename,"wb").write(file.FileData)
         if (file.ExtName in ["srt", "txt", "ssa", "smi", "sub"]):
             subs_file = filename
     return False, language, subs_file #standard output

--- a/script.xbmc.subtitles/resources/lib/utilities.py
+++ b/script.xbmc.subtitles/resources/lib/utilities.py
@@ -97,13 +97,13 @@ REGEX_EXPRESSIONS = [ '[Ss]([0-9]+)[][._-]*[Ee]([0-9]+)([^\\\\/]*)$',
 class UserNotificationNotifier:
   def __init__(self, title, initialMessage, time = -1):
     self.__title = title
-    xbmc.executebuiltin("Notification(%s,%s,%i)" % (title, initialMessage, time))
+    xbmc.executebuiltin((u"Notification(%s,%s,%i)" % (title, initialMessage, time)).encode('utf-8'))
     
   def update(self, message, time = -1):
-    xbmc.executebuiltin("Notification(%s,%s,-1)" % (self.__title, message, time))
+    xbmc.executebuiltin((u"Notification(%s,%s,-1)" % (self.__title, message, time)).encode("utf-8"))
 
   def close(self, message, time = -1):
-    xbmc.executebuiltin("Notification(%s,%s,%i)" % (self.__title, message, time)) 
+    xbmc.executebuiltin((u"Notification(%s,%s,%i)" % (self.__title, message, time)).encode("utf-8")) 
 
    
 def log(module,msg):
@@ -166,19 +166,12 @@ def rem_files(directory):
       for name in files:
         os.remove(os.path.join(root, name))
   except:
-    try:
-      for root, dirs, files in os.walk(directory, topdown=False):
-        for items in dirs:
-          shutil.rmtree(os.path.join(root, items).decode("utf-8"), ignore_errors=True, onerror=None)
-        for name in files:
-          os.remove(os.path.join(root, name).decode("utf-8"))
-    except:
-      pass 
+    pass 
       
 def copy_files( subtitle_file, file_path ):
   subtitle_set = False
   try:
-    xbmcvfs.copy(subtitle_file.encode("utf-8"), file_path.encode("utf-8"))
+    xbmcvfs.copy(subtitle_file, file_path)
     log( __name__ ,"vfs module copy %s -> %s" % (subtitle_file, file_path))
     subtitle_set = True
   except :


### PR DESCRIPTION
1. Use unicode as the default coding of XBMC Subtitle script. That meaning we decode all the charater into unicode when string transfer into this script, and only encode to utf-8 when needed.
2. xbmcvfs support unicode string as input, so not need encode to utf-8
