### PR TITLE
Fixed: Subtitle not show after download under windows because can't open...

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -317,8 +317,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
         file_name = u"%s.%s%s" % ( sub_name, sub_lang, sub_ext )
       else:
         file_name = u"%s%s" % ( sub_name, sub_ext )
-      file_from = file.replace('\\','/')
-      file_to = os.path.join(self.sub_folder, file_name).replace('\\','/')
+      file_from = file
+      file_to = os.path.join(self.sub_folder, file_name)
       # Create a files list of from-to tuples so that multiple files may be
       # copied (sub+idx etc')
       files_list = [(file_from,file_to)]


### PR DESCRIPTION
... the download file when replace \ to /.

Example: subtitle filename 'e:\movie\test.en.srt'
after replace \ to / file_to is 'e:/movie/test.en.srt'.
xbmc will cache filename 'e:/movie/test.en.srt' when call xbmcvfs.copy.
and when call xbmc.Player().setSubtitles(subtitle.encode("utf-8"))
subtitle is 'e:\movie\test.en.srt'
xbmc not find it in the cache, so can't open it.
