### PR TITLE
try other methods of extracting subtitles when standard fails

### DIFF
--- a/script.xbmc.subtitles/resources/language/English/strings.xml
+++ b/script.xbmc.subtitles/resources/language/English/strings.xml
@@ -76,6 +76,12 @@
     <string id="30145">Use 'Subs' subfolder for storing subtitles</string>
     <string id="30146">- napisy24.pl Username</string>
     <string id="30147">- napisy24.pl Password</string>
+    <string id="30148">Try other methods if subtitles extract fails</string>
+    <string id="30149">- 7zip path (leave empty for standard)</string>
+    <string id="30150">- Unzip path (leave empty for standard)</string>
+    <string id="30151">- Unrar path (leave empty for standard)</string>
+    
+    
     
   <!-- Languages  -->
   

--- a/script.xbmc.subtitles/resources/language/Polish/strings.xml
+++ b/script.xbmc.subtitles/resources/language/Polish/strings.xml
@@ -69,9 +69,9 @@
     <string id="30146">- napisy24.pl Nazwa</string>
     <string id="30147">- napisy24.pl Hasło</string>
     <string id="30148">Spróbuj innych metod gdy wypakowanie napisów zawodzi</string>
-    <string id="30149">- Ścieżka do 7zip (pzostaw puste jesli standardowa)</string>
-    <string id="30150">- Ścieżka do Unzip (pzostaw puste jesli standardowa)</string>
-    <string id="30151">- Ścieżka do Unrar (pzostaw puste jesli standardowa)</string>
+    <string id="30149">- Ścieżka do 7zip (pozostaw puste jeśli standardowa)</string>
+    <string id="30150">- Ścieżka do Unzip (pozostaw puste jeśli standardowa)</string>
+    <string id="30151">- Ścieżka do Unrar (pozostaw puste jeśli standardowa)</string>
 
   <!-- Languages  -->    
        

--- a/script.xbmc.subtitles/resources/language/Polish/strings.xml
+++ b/script.xbmc.subtitles/resources/language/Polish/strings.xml
@@ -68,6 +68,10 @@
     <string id="30140">- Wybierz rodzaj napisów:</string>
     <string id="30146">- napisy24.pl Nazwa</string>
     <string id="30147">- napisy24.pl Hasło</string>
+    <string id="30148">Spróbuj innych metod gdy wypakowanie napisów zawodzi</string>
+    <string id="30149">- Ścieżka do 7zip (pzostaw puste jesli standardowa)</string>
+    <string id="30150">- Ścieżka do Unzip (pzostaw puste jesli standardowa)</string>
+    <string id="30151">- Ścieżka do Unrar (pzostaw puste jesli standardowa)</string>
 
   <!-- Languages  -->    
        

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -348,19 +348,44 @@ class GUI( xbmcgui.WindowXMLDialog ):
     sub_filename = os.path.basename( self.file_original_path )
     exts = [".srt", ".sub", ".txt", ".smi", ".ssa", ".ass" ]
     subtitle_set = False
-    if len(files) < 2 :
-      subprocess.call(['unzip', '-d', self.tmp_sub_dir, zip_subs])
-      xbmc.sleep(1000)
-      files = os.listdir(self.tmp_sub_dir)
-    elif len(files) < 2:
-      subprocess.call(['unrar', 'x', zip_subs, self.tmp_sub_dir])
-      xbmc.sleep(1000)
-    else:
-      if gui:
-        self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
-        self.show_service_list(gui)
-    files = os.listdir(self.tmp_sub_dir)    
-    if len(files) > 1 :
+    
+    if len(files) < 2: 
+        if __addon__.getSetting( "extendedextract" ) == "true":
+            if __addon__.getSetting("extendedextract7zpath") != '':
+                extcmd = __addon__.getSetting("extendedextract7zpath")
+            else:
+                extcmd = '7z'
+                if os.name == 'nt':
+                    extcmd = 'C:\Program Files\7-zip\7z.exe'
+            os.system((extcmd +' e -o' + self.tmp_sub_dir + ' ' + zip_subs))
+            xbmc.sleep(1000)
+            files = os.listdir(self.tmp_sub_dir)
+            if len(files) < 2: 
+                if __addon__.getSetting("extendedextractunzippath") != '':
+                    extcmd = __addon__.getSetting("extendedextractunzippath")
+                else:
+                    extcmd = 'unzip'
+                    if os.name == 'nt':
+                        extcmd = 'C:\Program Files\WinZip\unzip.exe'    
+                print extcmd
+                os.system((extcmd + ' -d ' + self.tmp_sub_dir + ' ' + zip_subs))
+                xbmc.sleep(1000)
+                files = os.listdir(self.tmp_sub_dir)
+            if len(files) < 2:
+                if __addon__.getSetting("extendedextractunrarpath") != '':
+                    extcmd = __addon__.getSetting("extendedextractunrarpath")
+                else:
+                    extcmd = 'unrar'
+                    if os.name == 'nt':
+                        extcmd = 'C:\Program Files\WinRAR\unrar.exe'
+                os.system([extcmd, 'x', zip_subs, self.tmp_sub_dir])
+                xbmc.sleep(1000)
+                files = os.listdir(self.tmp_sub_dir)
+        else:
+            if gui:
+                self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
+                self.show_service_list(gui)
+    if len(files) > 1:
       if gui:
         self.getControl( STATUS_LABEL ).setLabel( _( 652 ) )
       subtitle_set = False

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -8,6 +8,7 @@ import urllib
 import socket
 import xbmcgui
 import unicodedata
+import subprocess
 
 from utilities import *
 
@@ -342,15 +343,24 @@ class GUI( xbmcgui.WindowXMLDialog ):
   def Extract_Subtitles( self, zip_subs, subtitle_lang, gui = True ):
     xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip_subs,self.tmp_sub_dir,)).encode('utf-8'))
     xbmc.sleep(1000)
+    #exit();
     files = os.listdir(self.tmp_sub_dir)
     sub_filename = os.path.basename( self.file_original_path )
     exts = [".srt", ".sub", ".txt", ".smi", ".ssa", ".ass" ]
     subtitle_set = False
-    if len(files) < 1 :
+    if len(files) < 2 :
+      subprocess.call(['unzip', '-d', self.tmp_sub_dir, zip_subs])
+      xbmc.sleep(1000)
+      files = os.listdir(self.tmp_sub_dir)
+    elif len(files) < 2:
+      subprocess.call(['unrar', 'x', zip_subs, self.tmp_sub_dir])
+      xbmc.sleep(1000)
+    else:
       if gui:
         self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
         self.show_service_list(gui)
-    else :
+    files = os.listdir(self.tmp_sub_dir)    
+    if len(files) > 1 :
       if gui:
         self.getControl( STATUS_LABEL ).setLabel( _( 652 ) )
       subtitle_set = False

--- a/script.xbmc.subtitles/resources/settings.xml
+++ b/script.xbmc.subtitles/resources/settings.xml
@@ -80,5 +80,9 @@
       <setting id="search_next" type="bool" label="30130" default="false" />
       <setting id="auto_download" type="bool" label="30131" default="false" />
       <setting id="auto_download_file" visible= "false" type="text" label="" default="" />
+      <setting id="extendedextract" type="bool" label="30148" default="false" />
+      <setting id="extendedextract7zpath" type="text" visible= "eq(-1,true)" source="files" label="30149" default="" />
+      <setting id="extendedextractunzippath" type="text" visible= "eq(-2,true)" source="files" label="30150" default="" />
+      <setting id="extendedextractunrarpath" type="text" visible= "eq(-3,true)" source="files" label="30151" default="" />
     </category>
 </settings>


### PR DESCRIPTION
in very rare cases when subtitle in zip file has name consisting of ';' (yes somebody actually does that sic!) standard XBMCExtract fails so i made mod where you can try in this cases to extract using standard utils like 7z unzip and unrar. Example of such sub is here (first sub): http://napisy24.pl/search.php?str=vampire+diaries+3x22 
