### PR TITLE
Folder names properly used for lookup

### DIFF
--- a/script.xbmc.subtitles/addon.xml
+++ b/script.xbmc.subtitles/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmc.subtitles"
        name="XBMC Subtitles"
-       version="3.5.0"
-       provider-name="amet, mr_blobby">
+       version="3.5.1"
+       provider-name="amet, mr_blobby, popeye">
   <requires>
     <import addon="xbmc.python" version="2.0"/>
     <import addon="script.module.beautifulsoup" version="3.0.8"/>

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -128,8 +128,14 @@ class GUI( xbmcgui.WindowXMLDialog ):
 
     self.file_original_path = urllib.unquote ( movieFullPath )             # Movie Path
 
+    if self.parsearch:
+      self.title = os.path.basename(os.path.dirname( self.file_original_path )) # Title is foldername
+
     if (__addon__.getSetting( "fil_name" ) == "true"):                     # Display Movie name or search string
-      self.file_name = os.path.basename( movieFullPath )
+      if self.parsearch:                                                   # Display the folder name
+        self.file_name = self.title 
+      else:
+        self.file_name = os.path.basename( movieFullPath )
     else:
       if (len(str(self.year)) < 1 ) :
         self.file_name = self.title.encode('utf-8')
@@ -467,19 +473,20 @@ class GUI( xbmcgui.WindowXMLDialog ):
 
   def keyboard(self, parent):
     dir, self.year = xbmc.getCleanMovieTitle(self.file_original_path, self.parsearch)
-    if not parent:
-      if self.man_search_str != "":
-        srchstr = self.man_search_str
-      else:
-        srchstr = "%s (%s)" % (dir,self.year,)  
-      kb = xbmc.Keyboard(srchstr, _( 751 ), False)
-      text = self.file_name
-      kb.doModal()
-      if (kb.isConfirmed()): text, self.year = xbmc.getCleanMovieTitle(kb.getText())
-      self.title = text
-      self.man_search_str = text
+    if parent: # If "Use folder name for lookup"
+      dir = os.path.basename(os.path.dirname(self.file_original_path))
+    self.title = dir
+    if self.year != "" and not parent:
+      srchstr = "%s (%s)" % (dir,self.year,)
     else:
-      self.title = dir   
+      srchstr = dir
+    # Allways show keyboard
+    if self.man_search_str != "":
+      srchstr = self.man_search_str 
+    kb = xbmc.Keyboard(srchstr, _( 751 ), False)
+    kb.doModal()
+    if (kb.isConfirmed()): 
+      self.title = self.man_search_str = kb.getText()
 
     log( __name__ ,"Manual/Keyboard Entry: Title:[%s], Year: [%s]" % (self.title, self.year,))
     if self.year != "" :

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -481,21 +481,20 @@ class GUI( xbmcgui.WindowXMLDialog ):
     else:
       srchstr = dir
     # Allways show keyboard
-    if self.man_search_str != "":
+    if self.man_search_str != "": #We have a old search
       srchstr = self.man_search_str 
     kb = xbmc.Keyboard(srchstr, _( 751 ), False)
     kb.doModal()
     if (kb.isConfirmed()): 
       self.title = self.man_search_str = kb.getText()
-
-    log( __name__ ,"Manual/Keyboard Entry: Title:[%s], Year: [%s]" % (self.title, self.year,))
-    if self.year != "" :
-      self.file_name = "%s (%s)" % (self.file_name, str(self.year),)
-    else:
-      self.file_name = self.title   
-    self.tvshow = ""
-    self.next = list(self.service_list)
-    self.Search_Subtitles() 
+      log( __name__ ,"Manual/Keyboard Entry: Title:[%s], Year: [%s]" % (self.title, self.year,))
+      if self.year != "" :
+        self.file_name = "%s (%s)" % (self.file_name, str(self.year),)
+      else:
+        self.file_name = self.title   
+      self.tvshow = ""
+      self.next = list(self.service_list)
+      self.Search_Subtitles() 
 
   def onClick( self, controlId ):
     if controlId == SUBTITLES_LIST:


### PR DESCRIPTION
With this commit folder names are properly used as the search term when the setting is set. Also, when using the manual search methods, the keyboard is always displayed. The manual keyboard with the search term cleaned and the folder keyboard with the folder. The search is also not modified (i.e. not always cleaned)
