### PR TITLE
Make pausing during UI optional

### DIFF
--- a/script.xbmc.subtitles/default.py
+++ b/script.xbmc.subtitles/default.py
@@ -28,12 +28,14 @@ if ( __name__ == "__main__" ):
   if (ui.set_allparam()):
     notification = UserNotificationNotifier(__scriptname__, __language__(764), 2000)    
     if not ui.Search_Subtitles(False):
-      __unpause__ = pause()
+      if __addon__.getSetting("pause") == "true":
+        __unpause__ = pause()
       ui.doModal()
     else:
       notification.close(__language__(765), 1000) 
   else:
-    __unpause__ = pause() 
+    if __addon__.getSetting("pause") == "true":
+      __unpause__ = pause()
     ui.doModal()
         
   del ui

--- a/script.xbmc.subtitles/resources/language/English/strings.xml
+++ b/script.xbmc.subtitles/resources/language/English/strings.xml
@@ -88,6 +88,7 @@
     <string id="30157">Playing Title!</string>
     <string id="30158">- Pipocas Username</string>
     <string id="30159">- Pipocas Password</string>
+    <string id="30160">Pause while showing UI</string>
     
   <!-- Languages  -->
   

--- a/script.xbmc.subtitles/resources/settings.xml
+++ b/script.xbmc.subtitles/resources/settings.xml
@@ -85,6 +85,7 @@
       <setting id="use_subs_folder" type="bool" label="30145" default="false" />
       <setting id="timeout" type="enum" label="30122" default="6" values="0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" />
       <setting id="search_next" type="bool" label="30130" default="false" />
+      <setting id="pause" type="bool" label="30160" default="true" />
       <setting id="auto_download" type="bool" label="30131" default="false" />
       <setting id="auto_download_file" visible= "false" type="text" label="" default="" />
     </category>


### PR DESCRIPTION
Allows selecting and downloading subtitles without stopping the show.
Useful if subtitles are helpful, but not necessary. Default behaviour is
unmodified.
