### PR TITLE
Make pausing during UI optional

### DIFF
--- a/script.xbmc.subtitles/default.py
+++ b/script.xbmc.subtitles/default.py
@@ -26,7 +26,8 @@ if xbmc.Player().isPlayingVideo():
   pause = Pause()
   ui = gui.GUI( "script-XBMC-Subtitles-main.xml" , __cwd__ , "Default")
   if (not ui.set_allparam() or not ui.Search_Subtitles(False)):
-    pause.pause()
+    if __addon__.getSetting("pause") == "true":
+      pause.pause()
     ui.doModal()
         
   del ui

--- a/script.xbmc.subtitles/resources/language/English/strings.po
+++ b/script.xbmc.subtitles/resources/language/English/strings.po
@@ -380,7 +380,11 @@ msgctxt "#30159"
 msgid "- Pipocas Password"
 msgstr ""
 
-#empty strings from id 30160 to 30200
+msgctxt "#30160"
+msgid "Pause while showing UI"
+msgstr ""
+
+#empty strings from id 30161 to 30200
 #Languages
 
 msgctxt "#30201"

--- a/script.xbmc.subtitles/resources/settings.xml
+++ b/script.xbmc.subtitles/resources/settings.xml
@@ -85,6 +85,7 @@
       <setting id="use_subs_folder" type="bool" label="30145" default="false" />
       <setting id="timeout" type="enum" label="30122" default="6" values="0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" />
       <setting id="search_next" type="bool" label="30130" default="false" />
+      <setting id="pause" type="bool" label="30160" default="true" />
       <setting id="auto_download" type="bool" label="30131" default="false" />
       <setting id="auto_download_file" visible= "false" type="text" label="" default="" />
     </category>


### PR DESCRIPTION
Allows selecting and downloading subtitles without stopping the show.
Useful if subtitles are helpful, but not necessary. Default behaviour is
unmodified.

Cherry-picked from b204b80c9f6f6cd12728f5ee35974591fcdb81c2.

Conflicts:
    script.xbmc.subtitles/default.py
    script.xbmc.subtitles/resources/language/English/strings.xml
