### PR TITLE
Added option "Convert to UTF-8"

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -59,6 +59,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
     self.language_3      = languageTranslate(__addon__.getSetting( "Lang03" ), 4, 0)     # Full language 3
     self.tmp_sub_dir     = os.path.join( __profile__ ,"sub_tmp" )                        # Temporary subtitle extraction directory   
     self.stream_sub_dir  = os.path.join( __profile__ ,"sub_stream" )                     # Stream subtitle directory    
+    self.recode_utf8     = __addon__.getSetting( "recode_utf8" )                         # Convert to UTF-8
     
     self.clean_temp()                                                                   # clean temp dirs
     
@@ -326,6 +327,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
       # Choose the last pair in the list, second item (destination file)
       if subtitle_set:
         subtitle = files_list[-1][1]
+        if self.recode_utf8:
+          recode_to_utf8(subtitle, sub_lang)
         xbmc.Player().setSubtitles(subtitle.encode("utf-8"))
         self.close()
       else:
@@ -387,6 +390,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
             subtitle_set,subToActivate  = copy_files( subtitle_file, file_path )
 
     if subtitle_set :
+      if self.recode_utf8:
+        recode_to_utf8(subToActivate, subtitle_lang)
       xbmc.Player().setSubtitles(subToActivate.encode("utf-8"))
       self.close()
     else:

--- a/script.xbmc.subtitles/resources/lib/utilities.py
+++ b/script.xbmc.subtitles/resources/lib/utilities.py
@@ -299,6 +299,38 @@ def getShowId():
       return json.loads(xbmc.executeJSONRPC (tvdbid_query))['result']['tvshowdetails']['imdbnumber']
     except:
       log( __name__ ," Failed to find TVDBid in database")  
-    
 
+# Inspired by http://gomputor.wordpress.com/2008/09/22/convert-a-file-in-utf-8-or-any-encoding-with-python/
+def recode_to_utf8(file_path, lang):
+    encodings = {
+	"cs": ("windows-1250", "iso-8859-2"),
+	"el": ("windows-1253", "iso-8859-7", "macgreek"),
+    }
 
+    if lang not in encodings.keys():
+	return
+
+    # read file contents
+    try:
+	f = xbmcvfs.File(file_path)
+	data = f.read()
+	f.close()
+    except:
+	return
+
+    # decode file contents
+    for enc in encodings[lang]:
+	try:
+	    data = data.decode(enc)
+	    break
+	except:
+	    if enc == encodings[lang][-1]:
+		return
+	    continue
+
+    # write recoded subtitles
+    f = xbmcvfs.File(file_path, "w")
+    try:
+	f.write(data.encode("utf-8"))
+    finally:
+	f.close()

--- a/script.xbmc.subtitles/resources/settings.xml
+++ b/script.xbmc.subtitles/resources/settings.xml
@@ -91,5 +91,6 @@
       <setting id="pause" type="bool" label="30160" default="true" />
       <setting id="auto_download" type="bool" label="30131" default="false" />
       <setting id="auto_download_file" visible= "false" type="text" label="" default="" />
+      <setting id="recode_utf8" type="bool" label="Convert to UTF-8" default="false" />
     </category>
 </settings>


### PR DESCRIPTION
This option enables automatic subtitles conversion from language specific charsets to UTF-8.

It's handy at least for Czech (windows-1250, iso-8859-2). This patch is just a quick hack but it works fine for me.. Maybe someone else is also looking for something similar..
