### PR TITLE
Fix bug on the download calculation

### DIFF
--- a/script.xbmc.subtitles/resources/lib/services/Subdivx/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/Subdivx/service.py
@@ -45,7 +45,7 @@ def getallsubs(searchstring, languageshort, languagelong, file_original_path, su
             id = matches.group(4)
             no_files = matches.group(3)
             server = matches.group(5)
-            downloads = int(matches.group(2)) / 1000
+            downloads = int(re.sub(r',','',matches.group(2))) / 1000
             if (downloads > 10):
                 downloads=10
             filename = string.strip(matches.group(1))


### PR DESCRIPTION
Subdivx has changed the way that displays # of downloads. They are inserting a "," as a separator which causes a type mismatch error (1,001 is not an integer)
