### PR TITLE
Patch season not found error in some tv shows

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -107,6 +107,9 @@ class GUI( xbmcgui.WindowXMLDialog ):
     else:
       self.year = ""
 
+    if self.season == "":
+        title, self.season, self.episode = regex_tvshow(False, self.title)
+
     self.file_original_path = urllib.unquote ( movieFullPath )             # Movie Path
 
     if (__addon__.getSetting( "fil_name" ) == "true"):                     # Display Movie name or search string


### PR DESCRIPTION
In my raspberry pi, with xbmc, and using plex media server as video source, with certain tv shows, the script fails because at the point of running the initial search in set_allparams, because self.season is still "". This patch gets the season from regex_tvshow if that happens, preventing a ValueError on the casting of season to in a few lines after. 
Thanks for a great plugin!!

Óscar
