### PR TITLE
OpenSubtitles non-standard language naming breaking "Auto Download" feature.

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -239,12 +239,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
       subscounter = 0
       itemCount = 0
       list_subs = []
+      mainLangISO = languageTranslate(self.language_1, 0, 3)
       for item in self.subtitles_list:
-        if (self.autoDownload and 
-            item["sync"] and  
-            (item["language_name"] == languageTranslate(
-                languageTranslate(self.language_1,0,2),2,0)
-            )):
+        if (self.autoDownload and item["sync"] and
+            languageTranslate(item["language_name"], 0, 3) == mainLangISO
+        ):
           self.Download_Subtitles(itemCount, True, gui)
           __addon__.setSetting("auto_download_file",
                                os.path.basename( self.file_original_path ))

--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -13,12 +13,12 @@ from utilities import *
 _              = sys.modules[ "__main__" ].__language__
 __scriptname__ = sys.modules[ "__main__" ].__scriptname__
 __addon__      = sys.modules[ "__main__" ].__addon__
-__profile__    = sys.modules[ "__main__" ].__profile__ 
+__profile__    = sys.modules[ "__main__" ].__profile__
 __version__    = sys.modules[ "__main__" ].__version__
 
 class GUI( xbmcgui.WindowXMLDialog ):
-        
-  def __init__( self, *args, **kwargs ):        
+
+  def __init__( self, *args, **kwargs ):
     pass
 
   def onInit( self ):
@@ -33,14 +33,14 @@ class GUI( xbmcgui.WindowXMLDialog ):
     except:
       errno, errstr = sys.exc_info()[:2]
       xbmc.sleep(2000)
-      self.close()      
+      self.close()
 
-  def set_allparam(self):       
+  def set_allparam(self):
     self.list            = []
     service_list         = []
     self.stackPath       = []
     service              = ""
-    self.man_search_str  = ""   
+    self.man_search_str  = ""
     self.temp            = False
     self.rar             = False
     self.stack           = False
@@ -56,13 +56,13 @@ class GUI( xbmcgui.WindowXMLDialog ):
     self.mansearch       =  __addon__.getSetting( "searchstr" ) == "true"                # Manual search string??
     self.parsearch       =  __addon__.getSetting( "par_folder" ) == "true"               # Parent folder as search string
     self.language_1      = languageTranslate(__addon__.getSetting( "Lang01" ), 4, 0)     # Full language 1
-    self.language_2      = languageTranslate(__addon__.getSetting( "Lang02" ), 4, 0)     # Full language 2  
+    self.language_2      = languageTranslate(__addon__.getSetting( "Lang02" ), 4, 0)     # Full language 2
     self.language_3      = languageTranslate(__addon__.getSetting( "Lang03" ), 4, 0)     # Full language 3
-    self.tmp_sub_dir     = os.path.join( __profile__ ,"sub_tmp" )                        # Temporary subtitle extraction directory   
-    self.stream_sub_dir  = os.path.join( __profile__ ,"sub_stream" )                     # Stream subtitle directory    
-    
+    self.tmp_sub_dir     = os.path.join( __profile__ ,"sub_tmp" )                        # Temporary subtitle extraction directory
+    self.stream_sub_dir  = os.path.join( __profile__ ,"sub_stream" )                     # Stream subtitle directory
+
     self.clean_temp()                                                                   # clean temp dirs
-    
+
     if ( movieFullPath.find("http") > -1 ):
       self.sub_folder = self.stream_sub_dir
       self.temp = True
@@ -70,7 +70,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
     elif ( movieFullPath.find("rar://") > -1 ):
       self.rar = True
       movieFullPath = os.path.dirname(movieFullPath[6:])
-    
+
     elif ( movieFullPath.find("stack://") > -1 ):
       self.stackPath = movieFullPath.split(" , ")
       movieFullPath = self.stackPath[0][8:]
@@ -82,11 +82,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
         xbmcvfs.mkdirs(self.sub_folder)
       else:
         self.sub_folder = os.path.dirname( movieFullPath )
-    
+
     if not xbmcvfs.exists(self.sub_folder):
       xbmcvfs.mkdir(self.sub_folder)
-    
-    if self.episode.lower().find("s") > -1:                                      # Check if season is "Special"             
+
+    if self.episode.lower().find("s") > -1:                                      # Check if season is "Special"
       self.season = "0"                                                          #
       self.episode = self.episode[-1:]                                           #
 
@@ -121,9 +121,9 @@ class GUI( xbmcgui.WindowXMLDialog ):
                                               int(self.episode)
                                              )
       else:
-        self.file_name = "%s (%s)" % (self.title.encode('utf-8'), str(self.year),)
+        self.file_name = "%s (%s)" % (self.title.encode('utf-8'), str(self.year))
 
-    if ((__addon__.getSetting( "auto_download" ) == "true") and 
+    if ((__addon__.getSetting( "auto_download" ) == "true") and
         (__addon__.getSetting( "auto_download_file" ) != os.path.basename( movieFullPath ))):
          self.autoDownload = True
          __addon__.setSetting("auto_download_file", "")
@@ -138,15 +138,15 @@ class GUI( xbmcgui.WindowXMLDialog ):
       def_service = __addon__.getSetting( "deftvservice")
     else:
       def_service = __addon__.getSetting( "defmovieservice")
-      
+
     if service_list.count(def_service) > 0:
       service = def_service
 
-    if len(service_list) > 0:  
+    if len(service_list) > 0:
       if len(service) < 1:
         self.service = service_list[0]
       else:
-        self.service = service  
+        self.service = service
 
       self.service_list = service_list
       self.next = list(service_list)
@@ -164,10 +164,10 @@ class GUI( xbmcgui.WindowXMLDialog ):
       log( __name__ ,"Tv Show Episode: [%s]"       % self.episode)
       log( __name__ ,"Movie/Episode Title: [%s]"   % self.title)
       log( __name__ ,"Subtitle Folder: [%s]"       % self.sub_folder)
-      log( __name__ ,"Languages: [%s] [%s] [%s]"   % (self.language_1, self.language_2, self.language_3,))
+      log( __name__ ,"Languages: [%s] [%s] [%s]"   % (self.language_1, self.language_2, self.language_3))
       log( __name__ ,"Parent Folder Search: [%s]"  % self.parsearch)
       log( __name__ ,"Stacked(CD1/CD2)?: [%s]"     % self.stack)
-  
+
     return self.autoDownload
 
   def Search_Subtitles( self, gui = True ):
@@ -185,11 +185,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
     exec ( "from services.%s import service as Service" % (self.service))
     self.Service = Service
     if gui:
-      self.getControl( STATUS_LABEL ).setLabel( _( 646 ) )
+      self.getControl( STATUS_LABEL ).setLabel( _( 646 ))
     msg = ""
     socket.setdefaulttimeout(float(__addon__.getSetting( "timeout" )))
-    try: 
-      self.subtitles_list, self.session_id, msg = self.Service.search_subtitles( 
+    try:
+      self.subtitles_list, self.session_id, msg = self.Service.search_subtitles(
                                                        self.file_original_path,
                                                        self.title,
                                                        self.tvshow,
@@ -214,7 +214,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
       msg = "Error: %s" % ( str(errstr), )
     socket.setdefaulttimeout(None)
     if gui:
-      self.getControl( STATUS_LABEL ).setLabel( _( 642 ) % ( "...", ) )
+      self.getControl( STATUS_LABEL ).setLabel( _( 642 ) % ( "...", ))
 
     if not self.subtitles_list:
       if __addon__.getSetting( "search_next" )== "true" and len(self.next) > 1:
@@ -222,7 +222,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
         self.next.remove(self.service)
         self.service = self.next[0]
         self.show_service_list(gui)
-        log( __name__ ,"Auto Searching '%s' Service" % (self.service,) )
+        log( __name__ ,"Auto Searching '%s' Service" % (self.service))
         self.Search_Subtitles(gui)
       else:
         self.next = list(self.service_list)
@@ -231,10 +231,10 @@ class GUI( xbmcgui.WindowXMLDialog ):
           if msg != "":
             self.getControl( STATUS_LABEL ).setLabel( msg )
           else:
-            self.getControl( STATUS_LABEL ).setLabel( _( 657 ) )
+            self.getControl( STATUS_LABEL ).setLabel( _( 657 ))
           self.show_service_list(gui)
-      if self.autoDownload:    
-        xbmc.executebuiltin((u"Notification(%s,%s,%i)" % (__scriptname__, _(767), 1000)).encode("utf-8"))    
+      if self.autoDownload:
+        xbmc.executebuiltin((u"Notification(%s,%s,%i)" % (__scriptname__, _(767), 1000)).encode("utf-8"))
     else:
       subscounter = 0
       itemCount = 0
@@ -252,7 +252,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
           return True
         else:
           if gui:
-            listitem = xbmcgui.ListItem(label=_( languageTranslate(item["language_name"],0,5) ),
+            listitem = xbmcgui.ListItem(label=_( languageTranslate(item["language_name"],0,5)),
                                         label2=item["filename"],
                                         iconImage=item["rating"],
                                         thumbnailImage=item["language_flag"]
@@ -266,28 +266,28 @@ class GUI( xbmcgui.WindowXMLDialog ):
               listitem.setProperty( "hearing_imp", "true" )
             else:
               listitem.setProperty( "hearing_imp", "false" )
-              
+
             self.list.append(subscounter)
             subscounter = subscounter + 1
-            list_subs.append(listitem)                                 
+            list_subs.append(listitem)
         itemCount += 1
-      
+
       if gui:
-        label = '%i %s '"' %s '"'' % (len ( self.subtitles_list ),_( 744 ),self.file_name,)
-        self.getControl( STATUS_LABEL ).setLabel( label ) 
+        label = '%i %s '"' %s '"'' % (len ( self.subtitles_list ),_( 744 ),self.file_name)
+        self.getControl( STATUS_LABEL ).setLabel( label )
         self.getControl( SUBTITLES_LIST ).addItems( list_subs )
         self.setFocusId( SUBTITLES_LIST )
         self.getControl( SUBTITLES_LIST ).selectItem( 0 )
-      if self.autoDownload:    
+      if self.autoDownload:
         xbmc.executebuiltin((u"Notification(%s,%s,%i)" % (__scriptname__, _(767), 1000)).encode("utf-8"))
       return False
 
   def Download_Subtitles( self, pos, auto = False, gui = True ):
     if gui:
       if auto:
-        self.getControl( STATUS_LABEL ).setLabel(  _( 763 ) )
+        self.getControl( STATUS_LABEL ).setLabel(  _( 763 ))
       else:
-        self.getControl( STATUS_LABEL ).setLabel(  _( 649 ) )
+        self.getControl( STATUS_LABEL ).setLabel(  _( 649 ))
     compressed_subs = os.path.join( self.tmp_sub_dir, "compressed_subs.ext")
     compressed, language, file = self.Service.download_subtitles(self.subtitles_list,
                                                              pos,
@@ -310,8 +310,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
       sub_ext  = os.path.splitext( file )[1]
       if self.temp:
         sub_name = "temp_sub"
-      else:  
-        sub_name = os.path.splitext( os.path.basename( self.file_original_path ) )[0]
+      else:
+        sub_name = os.path.splitext( os.path.basename( self.file_original_path ))[0]
       if (__addon__.getSetting( "lang_to_end" ) == "true"):
         file_name = u"%s.%s%s" % ( sub_name, sub_lang, sub_ext )
       else:
@@ -335,11 +335,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
         self.close()
       else:
         if gui:
-          self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
+          self.getControl( STATUS_LABEL ).setLabel( _( 654 ))
           self.show_service_list(gui)
 
   def Extract_Subtitles( self, zip_subs, subtitle_lang, gui = True ):
-    xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip_subs,self.tmp_sub_dir,)).encode('utf-8'))
+    xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip_subs,self.tmp_sub_dir)).encode('utf-8'))
     xbmc.sleep(1000)
     files = os.listdir(self.tmp_sub_dir)
     sub_filename = os.path.basename( self.file_original_path )
@@ -347,11 +347,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
     subtitle_set = False
     if len(files) < 1 :
       if gui:
-        self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
+        self.getControl( STATUS_LABEL ).setLabel( _( 654 ))
         self.show_service_list(gui)
     else :
       if gui:
-        self.getControl( STATUS_LABEL ).setLabel( _( 652 ) )
+        self.getControl( STATUS_LABEL ).setLabel( _( 652 ))
       subtitle_set = False
       movie_sub = False
       episode = 0
@@ -364,7 +364,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
           else:
             if os.path.splitext( zip_entry )[1] in exts:
               movie_sub = True
-          if ( movie_sub or int(episode) == int(self.episode) ):
+          if ( movie_sub or int(episode) == int(self.episode)):
             if self.stack:
               try:
                 for subName in self.stackPath:
@@ -377,11 +377,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
                                                     urllib.unquote(os.path.basename(subName[8:])),
                                                     subtitle_lang
                                                                )
-                    subtitle_set,file_path = copy_files( subtitle_file, file_path ) 
+                    subtitle_set,file_path = copy_files( subtitle_file, file_path )
                 if re.split("(?x)(?i)\CD(\d)", zip_entry)[1] == "1":
                   subToActivate = file_path
               except:
-                subtitle_set = False              
+                subtitle_set = False
             else:
               subtitle_set,subToActivate = copy_files( subtitle_file, file_path )
 
@@ -396,14 +396,14 @@ class GUI( xbmcgui.WindowXMLDialog ):
       self.close()
     else:
       if gui:
-        self.getControl( STATUS_LABEL ).setLabel( _( 654 ) )
+        self.getControl( STATUS_LABEL ).setLabel( _( 654 ))
         self.show_service_list(gui)
 
   def clean_temp( self ):
     for temp_dir in [self.stream_sub_dir,self.tmp_sub_dir]:
-      rem_files(temp_dir) 
-      
-      
+      rem_files(temp_dir)
+
+
   def show_service_list(self,gui):
     try:
       select_index = self.service_list.index(self.service)
@@ -413,19 +413,19 @@ class GUI( xbmcgui.WindowXMLDialog ):
       self.setFocusId( SERVICES_LIST )
       self.getControl( SERVICES_LIST ).selectItem( select_index )
 
-  def create_name(self,zip_entry,sub_filename,subtitle_lang): 
+  def create_name(self,zip_entry,sub_filename,subtitle_lang):
     if self.temp:
       name = "temp_sub"
     else:
       name = os.path.splitext( sub_filename )[0]
     if (__addon__.getSetting( "lang_to_end" ) == "true"):
-      file_name = u"%s.%s%s" % ( name, 
+      file_name = u"%s.%s%s" % ( name,
                                  subtitle_lang,
                                  os.path.splitext( zip_entry )[1] )
     else:
       file_name = u"%s%s" % ( name, os.path.splitext( zip_entry )[1] )
     log( __name__ ,"Sub in Archive [%s], File Name [%s]" % (zip_entry,
-                                                        file_name,))
+                                                        file_name))
     ret_zip_entry = xbmc.validatePath(os.path.join(self.tmp_sub_dir,zip_entry)).decode("utf-8")
     ret_file_name = xbmc.validatePath(os.path.join(self.sub_folder,file_name)).decode("utf-8")
     return ret_zip_entry,ret_file_name
@@ -433,7 +433,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
   def list_services( self ):
     self.list = []
     all_items = []
-    self.getControl( SERVICES_LIST ).reset() 
+    self.getControl( SERVICES_LIST ).reset()
     for serv in self.service_list:
       listitem = xbmcgui.ListItem( serv )
       self.list.append(serv)
@@ -441,22 +441,22 @@ class GUI( xbmcgui.WindowXMLDialog ):
       all_items.append(listitem)
 
     if self.mansearch :
-        listitem = xbmcgui.ListItem( _( 612 ) )
+        listitem = xbmcgui.ListItem( _( 612 ))
         listitem.setProperty( "man", "true" )
         self.list.append("Man")
         all_items.append(listitem)
 
     if self.parsearch :
-        listitem = xbmcgui.ListItem( _( 747 ) )
+        listitem = xbmcgui.ListItem( _( 747 ))
         listitem.setProperty( "man", "true" )
         self.list.append("Par")
         all_items.append(listitem)
-      
-    listitem = xbmcgui.ListItem( _( 762 ) )
+
+    listitem = xbmcgui.ListItem( _( 762 ))
     listitem.setProperty( "man", "true" )
     self.list.append("Set")
     all_items.append(listitem)
-    self.getControl( SERVICES_LIST ).addItems( all_items )    
+    self.getControl( SERVICES_LIST ).addItems( all_items )
 
   def keyboard(self, parent):
     dir, self.year = xbmc.getCleanMovieTitle(self.file_original_path, self.parsearch)
@@ -464,7 +464,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
       if self.man_search_str != "":
         srchstr = self.man_search_str
       else:
-        srchstr = "%s (%s)" % (dir,self.year,)  
+        srchstr = "%s (%s)" % (dir,self.year)
       kb = xbmc.Keyboard(srchstr, _( 751 ), False)
       text = self.file_name
       kb.doModal()
@@ -472,26 +472,26 @@ class GUI( xbmcgui.WindowXMLDialog ):
       self.title = text
       self.man_search_str = text
     else:
-      self.title = dir   
+      self.title = dir
 
-    log( __name__ ,"Manual/Keyboard Entry: Title:[%s], Year: [%s]" % (self.title, self.year,))
+    log( __name__ ,"Manual/Keyboard Entry: Title:[%s], Year: [%s]" % (self.title, self.year))
     if self.year != "" :
-      self.file_name = "%s (%s)" % (self.file_name, str(self.year),)
+      self.file_name = "%s (%s)" % (self.file_name, str(self.year))
     else:
-      self.file_name = self.title   
+      self.file_name = self.title
     self.tvshow = ""
     self.next = list(self.service_list)
-    self.Search_Subtitles() 
+    self.Search_Subtitles()
 
   def onClick( self, controlId ):
     if controlId == SUBTITLES_LIST:
-      self.Download_Subtitles( self.getControl( SUBTITLES_LIST ).getSelectedPosition() )
-          
+      self.Download_Subtitles( self.getControl( SUBTITLES_LIST ).getSelectedPosition())
+
     elif controlId == SERVICES_LIST:
       xbmc.executebuiltin("Skin.Reset(SubtitleSourceChooserVisible)")
-      selection = str(self.list[self.getControl( SERVICES_LIST ).getSelectedPosition()]) 
+      selection = str(self.list[self.getControl( SERVICES_LIST ).getSelectedPosition()])
       self.setFocusId( 120 )
-   
+
       if selection == "Man":
         self.keyboard(False)
       elif selection == "Par":
@@ -499,11 +499,11 @@ class GUI( xbmcgui.WindowXMLDialog ):
       elif selection == "Set":
         __addon__.openSettings()
         self.set_allparam()
-        self.on_run()        
+        self.on_run()
       else:
         self.service = selection
         self.next = list(self.service_list)
-        self.Search_Subtitles()      
+        self.Search_Subtitles()
 
   def onFocus( self, controlId ):
     if controlId == 150:

--- a/script.xbmc.subtitles/resources/lib/utilities.py
+++ b/script.xbmc.subtitles/resources/lib/utilities.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import os
 import re
@@ -29,9 +29,9 @@ CANCEL_DIALOG  = ( 9, 10, 13, 92, 216, 247, 257, 275, 61467, 61448, )
 SERVICE_DIR    = os.path.join(__cwd__, "resources", "lib", "services")
 
 LANGUAGES      = (
-    
+
     # Full Language name[0]     podnapisi[1]  ISO 639-1[2]   ISO 639-1 Code[3]   Script Setting Language[4]   localized name id number[5]
-    
+
     ("Albanian"                   , "29",       "sq",            "alb",                 "0",                     30201  ),
     ("Arabic"                     , "12",       "ar",            "ara",                 "1",                     30202  ),
     ("Belarusian"                 , "0" ,       "hy",            "arm",                 "2",                     30203  ),
@@ -95,7 +95,7 @@ LANGUAGES      = (
 
 
 REGEX_EXPRESSIONS = [ '[Ss]([0-9]+)[][._-]*[Ee]([0-9]+)([^\\\\/]*)$',
-                      '[\._ \-]([0-9]+)x([0-9]+)([^\\/]*)',                     # foo.1x09 
+                      '[\._ \-]([0-9]+)x([0-9]+)([^\\/]*)',                     # foo.1x09
                       '[\._ \-]([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',          # foo.109
                       '([0-9]+)([0-9][0-9])([\._ \-][^\\/]*)',
                       '[\\\\/\\._ -]([0-9]+)([0-9][0-9])[^\\/]*',
@@ -115,46 +115,46 @@ class Pause:
   def restore(self):
     if self.player_state != xbmc.getCondVisibility('Player.Paused'):
       xbmc.Player().pause()
-      
+
   def pause(self):
     if not xbmc.getCondVisibility('Player.Paused'):
       xbmc.Player().pause()
-   
+
 def log(module,msg):
-  xbmc.log((u"### [%s-%s] - %s" % (__scriptname__,module,msg,)).encode('utf-8'),level=xbmc.LOGDEBUG ) 
+  xbmc.log((u"### [%s-%s] - %s" % (__scriptname__,module,msg,)).encode('utf-8'),level=xbmc.LOGDEBUG )
 
 def regex_tvshow(compare, file, sub = ""):
   sub_info = ""
   tvshow = 0
-  
+
   for regex in REGEX_EXPRESSIONS:
-    response_file = re.findall(regex, file)                  
-    if len(response_file) > 0 : 
+    response_file = re.findall(regex, file)
+    if len(response_file) > 0 :
       log( __name__ , "Regex File Se: %s, Ep: %s," % (str(response_file[0][0]),str(response_file[0][1]),) )
       tvshow = 1
       if not compare :
         title = re.split(regex, file)[0]
-        for char in ['[', ']', '_', '(', ')','.','-']: 
+        for char in ['[', ']', '_', '(', ')','.','-']:
            title = title.replace(char, ' ')
         if title.endswith(" "): title = title[:-1]
         return title,response_file[0][0], response_file[0][1]
       else:
         break
-  
+
   if (tvshow == 1):
-    for regex in regex_expressions:       
+    for regex in regex_expressions:
       response_sub = re.findall(regex, sub)
       if len(response_sub) > 0 :
         try :
           sub_info = "Regex Subtitle Ep: %s," % (str(response_sub[0][1]),)
           if (int(response_sub[0][1]) == int(response_file[0][1])):
             return True
-        except: pass      
+        except: pass
     return False
   if compare :
     return True
   else:
-    return "","",""    
+    return "","",""
 
 def languageTranslate(lang, lang_from, lang_to):
   for x in LANGUAGES:
@@ -166,11 +166,11 @@ def pause():
     xbmc.Player().pause()
     return True
   else:
-    return False  
-    
+    return False
+
 def unpause():
   if xbmc.getCondVisibility('Player.Paused'):
-    xbmc.Player().pause()  
+    xbmc.Player().pause()
 
 def rem_files(directory):
   try:
@@ -178,10 +178,10 @@ def rem_files(directory):
       shutil.rmtree(directory)
   except:
     pass
-    
+
   if not xbmcvfs.exists(directory):
     os.makedirs(directory)
-      
+
 def copy_files( subtitle_file, file_path ):
   subtitle_set = False
   try:
@@ -205,18 +205,18 @@ def normalizeString(str):
 def hashFile(file_path, rar):
     if rar:
       return OpensubtitlesHashRar(file_path)
-      
-    log( __name__,"Hash Standard file")  
+
+    log( __name__,"Hash Standard file")
     longlongformat = 'q'  # long long
     bytesize = struct.calcsize(longlongformat)
     f = xbmcvfs.File(file_path)
-    
+
     filesize = f.size()
     hash = filesize
-    
+
     if filesize < 65536 * 2:
         return "SizeError"
-    
+
     buffer = f.read(65536)
     f.seek(max(0,filesize-65536),0)
     buffer += f.read(65536)
@@ -226,7 +226,7 @@ def hashFile(file_path, rar):
         (l_value,)= struct.unpack(longlongformat, buffer[size:size+bytesize])
         hash += l_value
         hash = hash & 0xFFFFFFFFFFFFFFFF
-    
+
     returnHash = "%016x" % hash
     return filesize,returnHash
 
@@ -240,11 +240,11 @@ def OpensubtitlesHashRar(firsrarfile):
     seek=0
     for i in range(4):
         f.seek(max(0,seek),0)
-        a=f.read(100)        
-        type,flag,size=struct.unpack( '<BHH', a[2:2+5]) 
+        a=f.read(100)
+        type,flag,size=struct.unpack( '<BHH', a[2:2+5])
         if 0x74==type:
             if 0x30!=struct.unpack( '<B', a[25:25+1])[0]:
-                raise Exception('Bad compression method! Work only for "store".')            
+                raise Exception('Bad compression method! Work only for "store".')
             s_partiizebodystart=seek+size
             s_partiizebody,s_unpacksize=struct.unpack( '<II', a[7:7+2*4])
             if (flag & 0x0100):
@@ -273,7 +273,7 @@ def addfilehash(name,hash,seek):
     for i in range(8192):
         hash+=struct.unpack('<q', f.read(8))[0]
         hash =hash & 0xffffffffffffffff
-    f.close()    
+    f.close()
     return hash
 
 def hashFileMD5(file_path, buff_size=1048576):
@@ -298,7 +298,4 @@ def getShowId():
       tvdbid_query = '{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShowDetails", "params": {"tvshowid": ' + str(tvshowid) + ', "properties": ["imdbnumber"]}, "id": 1}'
       return json.loads(xbmc.executeJSONRPC (tvdbid_query))['result']['tvshowdetails']['imdbnumber']
     except:
-      log( __name__ ," Failed to find TVDBid in database")  
-    
-
-
+      log( __name__ ," Failed to find TVDBid in database")


### PR DESCRIPTION
OpenSubtitles.org have a non-standard name for "BrazilianPortuguese" (they call it only "Brazilian", as you can see in http://www.opensubtitles.org/addons/export_languages.php).
The auto download feature checks the language name to download only the primary language and this difference was very annoying as it broke the feature--more frustrating: it says there is no "sync" matches and then presents me with a list that includes some "sync" matches.
I created a function to normalize these different namings ("NormalizeLangName", in utilities.py@163), although I think it may be an one-off situation. I though about checking the "language_id" ("pob", in this case) rather than the "language_name", but this is not available for all services and the "language_name" seems to be the only always available option.
It's a very minor change, but I tried to implement it in a feature-proof manner, so that it can fix other differences as well.
