### PR TITLE
fixed: Some movie filenames were treated as tvshows causing lookup failure

### DIFF
--- a/script.xbmc.subtitles/resources/lib/gui.py
+++ b/script.xbmc.subtitles/resources/lib/gui.py
@@ -97,14 +97,18 @@ class GUI( xbmcgui.WindowXMLDialog ):
       self.title  = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))      # no original title, get just Title :)
 
     if self.tvshow == "":
-      if str(self.year) == "":
-        title, season, episode = regex_tvshow(False, self.title)
-        if episode != "":
-          self.season = str(int(season))
-          self.episode = str(int(episode))
-          self.tvshow = title
-        else:
-          self.title, self.year = xbmc.getCleanMovieTitle( self.title )
+      if str(self.year) == "":                                            # If we have a year, assume no tv show
+        self.title, self.year = xbmc.getCleanMovieTitle( self.title )     # Clean before trying tvshow regex, else we get false results on some movies
+        if str(self.year) == "":                                          # Still no year: *could* be a tvshow
+          title, season, episode = regex_tvshow(False, self.title)
+          if title != "" and season != "" and episode != "":
+            self.season = str(int(season))
+            self.episode = str(int(episode))
+            self.tvshow = title
+          else:
+            self.season = ""                                              # Reset variables: could contain garbage from tvshow regex above
+            self.episode = ""
+            self.tvshow = ""
     else:
       self.year = ""
 


### PR DESCRIPTION
Many movie filenames use schemes like "Movie.(year).[x264-GROUP].ext" which were previously treated as tvshow obviously causing lookup to fail. This workaround fixes that. Note that I've also tested it with some of my tvshow/episode files, and it still seems to work for those too (although the orginal hack is still rather nasty -> perhaps we need some API function to pass the content type?)
