### PR TITLE
Fixed broken support for Ondertitel subtitle provider #2

### DIFF
--- a/script.xbmc.subtitles/resources/lib/services/Ondertitel/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/Ondertitel/service.py
@@ -38,7 +38,7 @@ subtitle_pattern = "<a href=\"(/ondertitels/info/.+?)\".+?<i class=\"i_font\">(.
 """
 <a href="/getdownload.php?id=45071&userfile=94 Avatar (2009) PROPER TS XviD-MAXSPEED.zip"><b>Download</b></a>
 """
-downloadlink_pattern = "a href=\"(http://[a-zA-Z0-9\-\.]+/getdownload.php\?id=\d{1,10}&userfile=.*?\.\w{3})\""
+downloadlink_pattern = "a href=\"http://[a-zA-Z0-9\-\.]+/(getdownload.php\?id=\d{1,10}&userfile=.*?\.\w{3})\""
 # group(1) = downloadlink
 
 #====================================================================================================================
@@ -139,10 +139,10 @@ def download_subtitles (subtitles_list, pos, zip_subs, tmp_sub_dir, sub_folder, 
 	downloadlink = getdownloadlink(content)
 	if downloadlink is not None:
 		try:
-			url = downloadlink
+			url = main_url + downloadlink
 			url = string.replace(url," ","+")
 			log( __name__ ,"%s Fetching subtitles using url %s - and cookie: %s" % (debug_pretext, url, cookie.cookies))
-			content = geturl(url, FETCH_SUBTITLE, cookie.cookies)
+			content = geturl(url, FETCH_SUBTITLE)
 			if content is not None:
 				log( __name__ ,"%s Saving subtitles to '%s'" % (debug_pretext, local_tmp_file))
 				local_file_handle = open(local_tmp_file, "w" + "b")


### PR DESCRIPTION
Fixed an error that was thrown when sending cookies with the download
request. Removed the cookies send with the download request.
Minor change to download link pattern to only return the last part of
the url when matched.
Succesfully tested on Openelec 3.2.3, XBMC on Linux and Windows
