### PR TITLE
fixed search URL for Subscene service

### DIFF
--- a/script.xbmc.subtitles/resources/lib/services/Subscene/service.py
+++ b/script.xbmc.subtitles/resources/lib/services/Subscene/service.py
@@ -193,9 +193,10 @@ def search_subtitles( file_original_path, title, tvshow, year, season, episode, 
     if len(tvshow) == 0:
         search_string = title
     if len(tvshow) > 0:
+        tvshow = string.strip(tvshow)
         search_string = tvshow + " - " + seasons[int(season)] + " Season"
     log( __name__ ,"%s Search string = %s" % (debug_pretext, search_string))
-    url = main_url + "/subtitles/title.aspx?q=" + urllib.quote_plus(search_string)
+    url = main_url + "/subtitles/title?q=" + urllib.quote_plus(search_string)
     content, response_url = geturl(url)
     if content is not None:
         if re.search("subtitles-\d{2,10}\.aspx", response_url, re.IGNORECASE):


### PR DESCRIPTION
Subscene service ceased to work due to a change to the search URL. This change fixes that.
